### PR TITLE
Add conversation memory feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ serde_json = "1.0"
 futures = "0.3"
 colored = "2.1"
 syntect = "5.2"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 bytes = "1.9"
+uuid = { version = "1.11", features = ["v4", "serde"] }


### PR DESCRIPTION
Implement session-based conversation memory with automatic continuation:
- Store conversations in ~/.cache/cmd2ai/ as JSON files
- Auto-continue conversations within 30 minutes
- Add command-line options:
  - --new/-n: Start fresh conversation
  - --continue/-c: Force continue expired sessions
  - --clear: Remove all conversation history
- Implement smart context trimming (keep last 3 exchanges)
- Add session management functions for save/load/clear
- Enable chrono serde feature for DateTime serialization
- Add uuid dependency for unique session IDs

The feature allows natural follow-up questions while managing context size and providing privacy through auto-expiring sessions.

🤖 Generated with [Claude Code](https://claude.ai/code)